### PR TITLE
feat(status): warn about stale project identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ built from, matched by publish timestamp: `v0.1.0` → `67a4776`, `v0.1.1` → `
 
 ## [Unreleased]
 
+### Added
+
+- **`nexusmem status` now warns when prior project identities still hold nodes.** A renamed git
+  remote can leave stale data under the old identity; status reports both the identity and node
+  counts and points to `sync --prune-source <name>` instead of leaving that data discoverable only
+  through a raw SQLite query.
+
 ## [0.3.3] — 2026-08-16
 
 ### Added

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -7,6 +7,8 @@ import { loadContext } from '../context.js';
 
 export interface StatusOptions {
   cwd: string;
+  /** Where the status report goes. Defaults to real stdout for the CLI. */
+  out?: (chunk: string) => void;
 }
 
 function humanBytes(bytes: number): string {
@@ -24,6 +26,7 @@ function fileSize(path: string): number {
 }
 
 export async function runStatus(opts: StatusOptions): Promise<number> {
+  const out = opts.out ?? ((chunk: string) => void process.stdout.write(chunk));
   const { repo, ws, projectId } = await loadContext(opts.cwd);
   const store = MemoryStore.open(ws.dbPath);
 
@@ -33,6 +36,8 @@ export async function runStatus(opts: StatusOptions): Promise<number> {
     const gitCursor = sources.find((s) => s.source === 'git')?.cursor ?? null;
     const schema = currentSchemaVersion(store.raw);
     const chains = getChainStats(store, projectId);
+    const otherProjectIds = store.listOtherProjectIds(projectId);
+    const otherProjectNodes = store.countProjectNodes(otherProjectIds);
 
     // WAL content counts towards what is actually on disk.
     const dbBytes = fileSize(ws.dbPath) + fileSize(`${ws.dbPath}-wal`);
@@ -40,14 +45,22 @@ export async function runStatus(opts: StatusOptions): Promise<number> {
     const kinds = Object.entries(stats.byKind)
       .sort((a, b) => b[1] - a[1])
       .map(([kind, n]) => `    ${String(n).padStart(6)}  ${kind}`);
+    const staleProjectWarning = otherProjectIds.length
+      ? `${pc.yellow('stale   ')} ${otherProjectIds.length} prior project ${
+          otherProjectIds.length === 1 ? 'identity holds' : 'identities hold'
+        } ${otherProjectNodes} node(s) — run ${pc.bold(
+          'nexusmem sync --prune-source <name>',
+        )} to remove stale source data`
+      : '';
 
-    process.stdout.write(
+    out(
       [
         `${pc.dim('repo    ')} ${repo.root}`,
         `${pc.dim('branch  ')} ${repo.branch ?? pc.yellow('(detached)')}`,
         `${pc.dim('project ')} ${pc.cyan(projectId)}`,
         `${pc.dim('schema  ')} v${schema}${schema === LATEST_SCHEMA_VERSION ? '' : pc.yellow(` (latest is v${LATEST_SCHEMA_VERSION})`)}`,
         `${pc.dim('database')} ${ws.dbPath} ${pc.dim(`(${humanBytes(dbBytes)})`)}`,
+        staleProjectWarning,
         '',
         `${pc.bold(String(stats.total))} node(s)${stats.total ? ` ${pc.dim(`${stats.oldest?.slice(0, 10)} .. ${stats.newest?.slice(0, 10)}`)}` : ''}`,
         ...kinds,

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -154,6 +154,16 @@ export class MemoryStore {
     );
   }
 
+  /** Total nodes held under the given project identities. */
+  countProjectNodes(projectIds: readonly string[]): number {
+    if (projectIds.length === 0) return 0;
+    const placeholders = projectIds.map(() => '?').join(', ');
+    const row = this.db
+      .prepare(`SELECT COUNT(*) AS n FROM nodes WHERE project_id IN (${placeholders})`)
+      .get(...projectIds) as { n: number };
+    return row.n;
+  }
+
   /**
    * Write a batch of nodes in one transaction.
    *

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runInit } from '../src/cli/commands/init.js';
+import { runStatus } from '../src/cli/commands/status.js';
+import { resolveWorkspace } from '../src/config/workspace.js';
+import { makeNodeId } from '../src/core/ids.js';
+import { makeProjectId } from '../src/core/project.js';
+import type { MemoryNode } from '../src/core/types.js';
+import { MemoryStore } from '../src/store/store.js';
+import { gitFixture } from './helpers.js';
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'T',
+  GIT_AUTHOR_EMAIL: 't@example.com',
+  GIT_COMMITTER_NAME: 'T',
+  GIT_COMMITTER_EMAIL: 't@example.com',
+};
+
+const REMOTE = 'https://example.com/acme/status.git';
+
+function initGitRepo(dir: string): void {
+  const git = (...args: string[]) => gitFixture(dir, args, { env: GIT_ENV });
+  git('init', '-q', '-b', 'main');
+  writeFileSync(join(dir, 'a.txt'), 'hello\n');
+  git('add', '.');
+  git('commit', '-q', '-m', 'chore: initial commit');
+  git('remote', 'add', 'origin', REMOTE);
+}
+
+function node(projectId: string, key: string): MemoryNode {
+  return {
+    id: makeNodeId(projectId, 'shell_command', key),
+    kind: 'shell_command',
+    projectId,
+    ts: '2026-01-01T00:00:00Z',
+    source: 'shell:pwsh',
+    title: `$ echo ${key}`,
+    body: `$ echo ${key}`,
+    files: [],
+    signal: 0.2,
+    meta: {},
+  };
+}
+
+describe('status stale project identities', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'nexusmem-status-'));
+    initGitRepo(dir);
+    await runInit({ cwd: dir, force: false, hook: false, enableConversation: false, out: () => {} });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function statusOutput(): Promise<string> {
+    const chunks: string[] = [];
+    await runStatus({ cwd: dir, out: (chunk) => chunks.push(chunk) });
+    return chunks.join('');
+  }
+
+  it('prints nothing extra when the database has no other project identity', async () => {
+    expect(await statusOutput()).not.toContain('prior project');
+  });
+
+  it('reports the identity and node counts with a cleanup hint', async () => {
+    const ws = resolveWorkspace(dir);
+    const staleProjectId = makeProjectId({
+      root: dir,
+      originUrl: 'https://example.com/acme/status-renamed-from.git',
+    });
+    const store = MemoryStore.open(ws.dbPath);
+    try {
+      store.upsertProject({
+        id: staleProjectId,
+        root: dir,
+        originUrl: 'https://example.com/acme/status-renamed-from.git',
+      });
+      store.upsertNodes([node(staleProjectId, 'one'), node(staleProjectId, 'two')]);
+    } finally {
+      store.close();
+    }
+
+    const output = await statusOutput();
+    expect(output).toContain('1 prior project identity holds 2 node(s)');
+    expect(output).toContain('nexusmem sync --prune-source <name>');
+  });
+});


### PR DESCRIPTION
## Summary

- detect prior project identities with `listOtherProjectIds`
- count their stored nodes with one aggregate query
- show one concise `nexusmem status` warning with exact identity/node counts and a `sync --prune-source <name>` cleanup hint
- keep the normal status output quiet when there is no stale identity
- add behavioral coverage and document the change in the changelog

`nexusmem status` does not currently support `--json`, so this stays text-only as allowed by the issue's conditional acceptance criterion rather than introducing a new output mode.

## Validation

- `npm run typecheck`
- `npm test` — 420 passed
- `npm run build`
- `npm run smoke` — 10/10 checks passed
- `git diff --check`

Closes #12